### PR TITLE
Use gradle logging to allow suppressing with quiet option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ task createApkDockerfileTasks() {
         String linuxFlavorDirName = getNameWithoutVersion(linuxFlavor)
         task "create${linuxFlavorDirName}Dockerfile"(type: Dockerfile) {
             destFile = project.file("${buildDir}/images/${linuxFlavorDirName}/${appName}/Dockerfile")
-            println "destFile: ${destFile}"
+            logger.lifecycle("destFile: ${destFile}")
             from linuxFlavor
             exposePort 8080
             runCommand 'apk update && apk add bash && apk add openjdk11-jre'
@@ -101,7 +101,7 @@ task createRpmDockerfileTasks() {
         String linuxFlavorDirName = getNameWithoutVersion(linuxFlavor)
         task "create${linuxFlavorDirName}Dockerfile"(type: Dockerfile) {
             destFile = project.file("${buildDir}/images/${linuxFlavorDirName}/${appName}/Dockerfile")
-            println "destFile: ${destFile}"
+            logger.lifecycle("destFile: ${destFile}")
             from linuxFlavor
             exposePort 8081
             runCommand 'yum update -y && yum install -y java-11-openjdk && yum clean all -y'
@@ -127,7 +127,7 @@ task createDpkgDockerfileTasks() {
         String linuxFlavorDirName = getNameWithoutVersion(linuxFlavor)
         task "create${linuxFlavorDirName}Dockerfile"(type: Dockerfile) {
             destFile = project.file("${buildDir}/images/${linuxFlavorDirName}/${appName}/Dockerfile")
-            println "destFile: ${destFile}"
+            logger.lifecycle("destFile: ${destFile}")
             from linuxFlavor
             exposePort 8082
             runCommand 'apt-get update -y && \
@@ -158,7 +158,7 @@ task createDockerfiles(dependsOn: [createdebianDockerfile, createfedoraDockerfil
 task createCopyJarToDockerfileDirTasks(type: Copy, dependsOn: [createDockerfiles]) {
 	linuxFlavors.eachWithIndex {linuxFlavor, index ->
 		String linuxFlavorDirName = getNameWithoutVersion(linuxFlavor)
-		println "Creating task to copy jar from build/libs/${project.name}-${version}.jar to Dockerfile dir for ${linuxFlavorDirName}, renaming to ${appName}-${version}.jar"
+		logger.lifecycle("Creating task to copy jar from build/libs/${project.name}-${version}.jar to Dockerfile dir for ${linuxFlavorDirName}, renaming to ${appName}-${version}.jar")
         task "copyJarToDockerfileDir_${linuxFlavorDirName}"(type: Copy, dependsOn: build) {
 			from "build/libs/${project.name}-${version}.jar"
 			into "${buildDir}/images/${linuxFlavorDirName}/${appName}"
@@ -175,7 +175,7 @@ task createRemoveDockerImageTasks() {
         String linuxFlavorDirName = getNameWithoutVersion(linuxFlavor)
         def taskName = "removeDockerImage_${linuxFlavorDirName}"
         String suffix = getSuffix(linuxFlavorDirName)
-        println "creating task ${taskName}"
+        logger.lifecycle("creating task ${taskName}")
         task "${taskName}"(type: Exec) {
 			ignoreExitValue true
             commandLine "docker", "rmi", "blackducksoftware/${appName}${suffix}:${version}"
@@ -191,7 +191,7 @@ task createBuildDockerImageTasks() {
         String linuxFlavorDirName = getNameWithoutVersion(linuxFlavor)
         def taskName = "buildDockerImage_${linuxFlavorDirName}"
         String suffix = getSuffix(linuxFlavorDirName)
-        println "creating task ${taskName}"
+        logger.lifecycle("creating task ${taskName}")
         task "${taskName}"(type: Exec, dependsOn: ["removeDockerImage_${linuxFlavorDirName}", buildImageDirs]) {
             commandLine "docker", "build", "--tag", "blackducksoftware/${appName}${suffix}:${version}", \
                 "${buildDir}/images/${linuxFlavorDirName}/${appName}"


### PR DESCRIPTION
The pre release tasks in our library runs: 
`./gradlew dependencies -q --configuration implementation`
It then parses the output looking for SNAPSHOT.

The problem is that the gradle quiet (-q) option does not suppress println statements, and line 161 prints SNAPSHOT in its output.

Update the calls to println to use logger.lifecycle so the output can be suppressed.

----------------------
Output of gradlew help with quiet option:
```
> ./gradlew help -q

Welcome to Gradle 6.8.2.

To run a build, run gradlew <task> ...

To see a list of available tasks, run gradlew tasks

To see a list of command-line options, run gradlew --help

To see more detail about a task, run gradlew help --task <task>

For troubleshooting, visit https://help.gradle.org
```
Output of gradlew help withOUT quiet option:
```
> ./gradlew help

> Configure project :
destFile: task ':createalpineDockerfile' property 'destFile'
destFile: task ':createfedoraDockerfile' property 'destFile'
destFile: task ':createdebianDockerfile' property 'destFile'
Creating task to copy jar from build/libs/blackduck-imageinspector-5.0.12-SNAPSHOT.jar to Dockerfile dir for debian, renaming to blackduck-imageinspector-5.0.12-SNAPSHOT.jar
Creating task to copy jar from build/libs/blackduck-imageinspector-5.0.12-SNAPSHOT.jar to Dockerfile dir for fedora, renaming to blackduck-imageinspector-5.0.12-SNAPSHOT.jar
Creating task to copy jar from build/libs/blackduck-imageinspector-5.0.12-SNAPSHOT.jar to Dockerfile dir for alpine, renaming to blackduck-imageinspector-5.0.12-SNAPSHOT.jar
creating task removeDockerImage_debian
creating task removeDockerImage_fedora
creating task removeDockerImage_alpine
creating task buildDockerImage_debian
creating task buildDockerImage_fedora
creating task buildDockerImage_alpine

> Task :help

Welcome to Gradle 6.8.2.

To run a build, run gradlew <task> ...

To see a list of available tasks, run gradlew tasks

To see a list of command-line options, run gradlew --help

To see more detail about a task, run gradlew help --task <task>

For troubleshooting, visit https://help.gradle.org

BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```