### PR TITLE
Update imageinspector-lib version used to latest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ publishing {
 ext['log4j2.version'] = '2.16.0'
 
 dependencies {
-    implementation 'com.synopsys.integration:hub-imageinspector-lib:14.1.3'
+    implementation 'com.synopsys.integration:hub-imageinspector-lib:14.1.4'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation 'io.micrometer:micrometer-registry-prometheus'


### PR DESCRIPTION
**JIRA Bug:**
[IDETECT-3588](https://jira-sig.internal.synopsys.com/browse/IDETECT-3588)

**Description:**
`integration-common` is a transitive dependency of `hub-imageinspector-ws` (used by the image inspector library) and to ensure hub-imageinspector-ws uses the latest version of `integration-common`, we update the image inspector library version to the latest release version i.e. `14.1.4`

Detect run:
https://us1a-int-hub02.nprd.sig.synopsys.com/api/projects/de1a9fcc-291f-48a1-a769-ebe95cfc5e13/versions/ff6d9c48-158c-4c9e-ad29-c782682b3906/components

