### PR TITLE
Resolve a filesystem permissions issue which occurred after Fedora upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ task createDpkgDockerfileTasks() {
             addFile("${appName}-${version}.jar", "${imagePgmDir}/${appName}.jar")
             runCommand "chown -R 10001 ${imagePgmDir}"
             runCommand "chmod -R g+w /var/lib/dpkg"
+            runCommand "chmod -R g+w /usr/lib/sysimage/rpm"
             runCommand "mkdir -p ${dockerInspectorDir}/config"
             runCommand "mkdir -p ${dockerInspectorDir}/target"
             runCommand "mkdir -p ${dockerInspectorDir}/output"

--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,7 @@ task createRpmDockerfileTasks() {
             addFile("${appName}-${version}.jar", "${imagePgmDir}/${appName}.jar")
             runCommand "chown -R 10001 ${imagePgmDir}"
             runCommand "chmod -R g+w /var/lib"
+            runCommand "chmod -R g+w /usr/lib/sysimage/rpm"
             runCommand "mkdir -p ${dockerInspectorDir}/config"
             runCommand "mkdir -p ${dockerInspectorDir}/target"
             runCommand "mkdir -p ${dockerInspectorDir}/output"
@@ -174,7 +175,6 @@ task createDpkgDockerfileTasks() {
             addFile("${appName}-${version}.jar", "${imagePgmDir}/${appName}.jar")
             runCommand "chown -R 10001 ${imagePgmDir}"
             runCommand "chmod -R g+w /var/lib/dpkg"
-            runCommand "chmod -R g+w /usr/lib/sysimage/rpm"
             runCommand "mkdir -p ${dockerInspectorDir}/config"
             runCommand "mkdir -p ${dockerInspectorDir}/target"
             runCommand "mkdir -p ${dockerInspectorDir}/output"


### PR DESCRIPTION
Resolve a filesystem permissions issue which occurred after Fedora upgrade.

Following a Fedora upgrade the following error started to be thrown:

```
Error inspecting image: There was a problem trying to getBdio. Error: 500; Warning header: ''; Body: 'Exception thrown while getting image packages: File parameter 'destDir is not writable: '/var/lib/rpm''
```

The mentioned `/var/lib/rpm` is a symlink to directory `/usr/lib/sysimage/rpm` which does not have write permissions for the group.
In the previous Fedora version we used `/var/lib/rpm` was a directory that did have group write permissions.