### PR TITLE
Fix Pop Coverity Job

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,6 +270,11 @@ task createPushTasks() {
             String tagWithoutRegistry = "blackducksoftware/${appName}${suffix}:${version}"
 
             doLast {
+                if (!internalDockerRegistry) {
+                    logger.error("Environment variable INTERNAL_DOCKER_REGISTRY is not set. Failing the build.")
+                    throw new GradleException("INTERNAL_DOCKER_REGISTRY environment variable is required but not set.")
+                }
+
                 for (String registry : dockerRegistries) {
                     logger.lifecycle("Pushing image ${tagWithoutRegistry} to registry ${registry}")
                     this.execCommand("docker", "tag", tagWithoutRegistry, "${registry}/${tagWithoutRegistry}")
@@ -281,10 +286,6 @@ task createPushTasks() {
 }
 
 task pushImages(dependsOn: [pushImage_alpine, pushImage_fedora, pushImage_debian]) {
-    if (!internalDockerRegistry) {
-        logger.error("Environment variable INTERNAL_DOCKER_REGISTRY is not set. Failing the build.")
-        throw new GradleException("INTERNAL_DOCKER_REGISTRY environment variable is required but not set.")
-    }
 }
 
 test.dependsOn testPrep

--- a/build.gradle
+++ b/build.gradle
@@ -46,11 +46,6 @@ repositories {
 // Additional registry to push images to in host:port format
 final def internalDockerRegistry = System.getenv('INTERNAL_DOCKER_REGISTRY')
 
-if (!internalDockerRegistry) {
-    logger.error("Environment variable INTERNAL_DOCKER_REGISTRY is not set. Failing the build.")
-    throw new GradleException("INTERNAL_DOCKER_REGISTRY environment variable is required but not set.")
-}
-
 String [] dockerRegistries = ["docker.io", internalDockerRegistry]
 
 version = '6.2.1-SNAPSHOT'
@@ -286,6 +281,10 @@ task createPushTasks() {
 }
 
 task pushImages(dependsOn: [pushImage_alpine, pushImage_fedora, pushImage_debian]) {
+    if (!internalDockerRegistry) {
+        logger.error("Environment variable INTERNAL_DOCKER_REGISTRY is not set. Failing the build.")
+        throw new GradleException("INTERNAL_DOCKER_REGISTRY environment variable is required but not set.")
+    }
 }
 
 test.dependsOn testPrep

--- a/build.gradle
+++ b/build.gradle
@@ -46,8 +46,6 @@ repositories {
 // Additional registry to push images to in host:port format
 final def internalDockerRegistry = System.getenv('INTERNAL_DOCKER_REGISTRY')
 
-String [] dockerRegistries = ["docker.io", internalDockerRegistry]
-
 version = '6.2.1-SNAPSHOT'
 def appName='blackduck-imageinspector'
 
@@ -274,6 +272,8 @@ task createPushTasks() {
                     logger.error("Environment variable INTERNAL_DOCKER_REGISTRY is not set. Failing the build.")
                     throw new GradleException("INTERNAL_DOCKER_REGISTRY environment variable is required but not set.")
                 }
+
+                String [] dockerRegistries = ["docker.io", internalDockerRegistry]
 
                 for (String registry : dockerRegistries) {
                     logger.lifecycle("Pushing image ${tagWithoutRegistry} to registry ${registry}")


### PR DESCRIPTION
This PR fixes pop coverity job by moving the check for DOCKER_REGISTRY variable inside the push Images job so that it is not a strict requirement for all builds to have.